### PR TITLE
Use `$config->get()` instead of `$config->string()`

### DIFF
--- a/src/routes/e2e.php
+++ b/src/routes/e2e.php
@@ -9,7 +9,7 @@ if (App::environment('local', 'testing')) {
 
     /** @var Repository  $config */
     $config = config();
-    $prefix = $config->string('app.e2e.prefix', '_testing');
+    $prefix = $config->get('app.e2e.prefix', '_testing');
 
     Route::prefix($prefix)->group(function () {
 


### PR DESCRIPTION
The Method `Illuminate\Config\Repository::string()` does not exist in Laravel 10. Use `Illuminate\Config\Repository::get()` instead.

Closes #2